### PR TITLE
Add descriptions on rosdep

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ xhost +local:
 docker exec -it choreonoid_workspace bash
 ```
 
+### Install dependencies via rosdep (Container)
+
+```bash
+apt-get update
+apt-get install python3-rosdep
+rosdep init
+rosdep install -i -y --from-path ~/ros2_ws/src
+```
+
 ### Build(Container)
 
 ```bash


### PR DESCRIPTION
This PR is for upcoming ros2_control support.

As ros2_control depends on multiple packages, using rosdep is a promising way to install them.